### PR TITLE
Update helper.js (fix error on iOS)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -78,7 +78,7 @@ export function subscribeToMediaQuery(mediaQuery, enter) {
 		mql.addEventListener("change", cb); //subscribing
 	} else {
 		// Deprecated property included for backwards compatibility
-		mql.addListener("change", cb);
+		mql.addListener(cb);
 	}
 	cb(mql); //initial trigger
 }


### PR DESCRIPTION
Deprecated addListener now conform to specs:
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener

