### PR TITLE
fix(package.json): :bug: Fix export module with new vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue3-mq",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue3-mq",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"dist/*"
 	],
 	"main": "./dist/vue3-mq.umd.js",
-	"module": "./dist/vue3-mq.es.js",
+	"module": "./dist/vue3-mq.js",
 	"browserslist": [
 		"> 1%",
 		"last 2 versions",


### PR DESCRIPTION
After Updating `vite` to version 3, `es` doesn't generate.