### PR TITLE
Fix vue import errors

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,3 +4,5 @@ declare module "vue" {
 		$mq: reactive;
 	}
 }
+
+export {};


### PR DESCRIPTION
Fixes #30. Fixes #31.

Adding `export {}` to the end of `global.d.ts` tells TypeScript not to overwrite all the vue types, but instead to merge.